### PR TITLE
feat(turbo_repo_remote_cache): Add conditional rule to create lambda function

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # By default, the team owns everything in the repo.
-*                          @TradrApi/TriceratOps
+*                          @funderpro/devops

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ task init
 With this in place all your commits will be checked for linting and formatting issues,
 according to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
 and our [`./commitlint.config.js`](./commitlint.config.js) file.
+

--- a/apps/turbo_repo_remote_cache/README.md
+++ b/apps/turbo_repo_remote_cache/README.md
@@ -26,6 +26,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_lambda"></a> [create\_lambda](#input\_create\_lambda) | n/a | `bool` | `true` | no |
 | <a name="input_extra_environment_variables"></a> [extra\_environment\_variables](#input\_extra\_environment\_variables) | n/a | `map(string)` | `{}` | no |
 | <a name="input_layers"></a> [layers](#input\_layers) | n/a | `list(string)` | `[]` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | n/a | `number` | `128` | no |

--- a/apps/turbo_repo_remote_cache/main.tf
+++ b/apps/turbo_repo_remote_cache/main.tf
@@ -1,4 +1,5 @@
 module "lambda" {
+  count   = var.create_lambda ? 1 : 0
   source  = "terraform-aws-modules/lambda/aws"
   version = "7.2.5"
 

--- a/apps/turbo_repo_remote_cache/outputs.tf
+++ b/apps/turbo_repo_remote_cache/outputs.tf
@@ -1,5 +1,5 @@
 output "lambda_function_url" {
-  value = module.lambda.lambda_function_url
+  value = var.create_lambda ? module.lambda[0].lambda_function_url : null
 }
 
 output "turbo_token" {

--- a/apps/turbo_repo_remote_cache/variables.tf
+++ b/apps/turbo_repo_remote_cache/variables.tf
@@ -28,3 +28,9 @@ variable "layers" {
   type    = list(string)
   default = []
 }
+
+
+variable "create_lambda" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
This pull request includes updates to the repository's ownership, as well as enhancements to the `apps/turbo_repo_remote_cache` module to add conditional support for Lambda creation. The most important changes include updating the default code owners, introducing a new `create_lambda` variable, and modifying related Terraform configuration files to respect this new variable.

### Ownership Updates:
* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L2-R2): Changed the default repository ownership from `@TradrApi/TriceratOps` to `@funderpro/devops`.

### Enhancements to Lambda Configuration:
* [`apps/turbo_repo_remote_cache/variables.tf`](diffhunk://#diff-b1f7a31f098e9511bb7237aa348743d9f98c4e9e9a252259ff845ec7dd88eb31R31-R36): Added a new `create_lambda` variable of type `bool`, with a default value of `true`. This variable determines whether a Lambda function should be created.
* [`apps/turbo_repo_remote_cache/main.tf`](diffhunk://#diff-4227aa77a04afe053a1af852a41cd1e186919dcd5acad94c0b2573c6ca688dd8R2): Updated the Lambda module configuration to use the `create_lambda` variable. The `count` attribute is set to `1` if `create_lambda` is `true`, otherwise `0`.
* [`apps/turbo_repo_remote_cache/outputs.tf`](diffhunk://#diff-cccdf04ef2ed6933c000ac210fe495ada44d98d3342c50d992b7ebdf048651f3L2-R2): Modified the `lambda_function_url` output to return the URL of the Lambda function if it is created, or `null` otherwise.
* [`apps/turbo_repo_remote_cache/README.md`](diffhunk://#diff-f7a1aade79a0348e1bb30a04be8f7e2e0194cf25a0cae62a5968fafe6e6e0199R29): Documented the new `create_lambda` variable in the module's input table.