### PR TITLE
feat(core): Fix pipeline flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.FUNDERPRO_GH_RELEASE_TOKEN }}
+
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a different secret token for the release process.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R23): Changed the token used by the `googleapis/release-please-action` from `${{ secrets.RELEASE_PLEASE_TOKEN }}` to `${{ secrets.FUNDERPRO_GH_RELEASE_TOKEN }}` to align with updated secret naming conventions.