### PR TITLE
fix(kafka,s3): migrate submodule sources to funderpro org

### DIFF
--- a/aws/kafka/backups.tf
+++ b/aws/kafka/backups.tf
@@ -1,5 +1,5 @@
 module "msk_s3_bkp" {
-  source = "github.com/TradrApi/terraform-modules//aws/s3?ref=v1"
+  source = "github.com/funderpro/terraform-modules//aws/s3?ref=v1"
 
   bucket_name = "${var.environment}-${var.platform}-msk-backup"
 

--- a/aws/kafka/plugins.tf
+++ b/aws/kafka/plugins.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 module "mskconnect_custom_plugins" {
-  source = "github.com/TradrApi/terraform-modules//aws/s3?ref=v1"
+  source = "github.com/funderpro/terraform-modules//aws/s3?ref=v1"
 
   bucket_name = "${var.environment}-${var.platform}-mskconnect-custom-plugins"
 

--- a/aws/kafka/users.tf
+++ b/aws/kafka/users.tf
@@ -1,5 +1,5 @@
 module "kms" {
-  source = "github.com/TradrApi/terraform-modules//aws/kms?ref=v1"
+  source = "github.com/funderpro/terraform-modules//aws/kms?ref=v1"
 
 
   name = "${terraform.workspace}-msk-sasl-scam"

--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -28,10 +28,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
   rule {
     id     = "Delete-${var.lifetime_days}-days"
-    status = "Enabled" # TODO what happened to enabled
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
 
     expiration {
-      days = var.lifetime_days # TODO is this the same value?
+      days = var.lifetime_days
     }
   }
 }


### PR DESCRIPTION


- Update aws/kafka submodule sources (backups, plugins, users) from TradrApi/terraform-modules to funderpro/terraform-modules
- Add required filter {} block to aws_s3_bucket_lifecycle_configuration to fix Invalid Attribute Combination warning in newer AWS provider versions