### PR TITLE
feat(ec2): Add throughput option for root and ebs volumes

### DIFF
--- a/aws/ec2/README.md
+++ b/aws/ec2/README.md
@@ -143,7 +143,7 @@ No modules.
 | <a name="input_attach_eip"></a> [attach\_eip](#input\_attach\_eip) | n/a | `bool` | `false` | no |
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | n/a | `string` | `null` | no |
 | <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | n/a | `bool` | `false` | no |
-| <a name="input_ebs"></a> [ebs](#input\_ebs) | n/a | <pre>object({<br/>    size        = number<br/>    device_name = optional(string, "xvdf")<br/>    az          = optional(string)<br/>    type        = optional(string)<br/>    iops        = optional(string)<br/>    tagName     = optional(string)<br/>  })</pre> | `null` | no |
+| <a name="input_ebs"></a> [ebs](#input\_ebs) | n/a | <pre>object({<br/>    size        = number<br/>    device_name = optional(string, "xvdf")<br/>    az          = optional(string)<br/>    type        = optional(string)<br/>    iops        = optional(string)<br/>    throughput  = optional(string)<br/>    tagName     = optional(string)<br/>  })</pre> | `null` | no |
 | <a name="input_get_password_data"></a> [get\_password\_data](#input\_get\_password\_data) | n/a | `bool` | `false` | no |
 | <a name="input_http_port"></a> [http\_port](#input\_http\_port) | n/a | `number` | `80` | no |
 | <a name="input_http_trusted_cidrs"></a> [http\_trusted\_cidrs](#input\_http\_trusted\_cidrs) | n/a | `list(string)` | `[]` | no |
@@ -162,6 +162,7 @@ No modules.
 | <a name="input_ssh_trusted_cidrs"></a> [ssh\_trusted\_cidrs](#input\_ssh\_trusted\_cidrs) | n/a | `list(string)` | `[]` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | n/a | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
+| <a name="input_throughput"></a> [throughput](#input\_throughput) | n/a | `number` | `null` | no |
 | <a name="input_type"></a> [type](#input\_type) | n/a | `string` | `"t2.micro"` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | n/a | `string` | `null` | no |
 | <a name="input_user_data_obj"></a> [user\_data\_obj](#input\_user\_data\_obj) | n/a | `any` | `null` | no |

--- a/aws/ec2/ebs.tf
+++ b/aws/ec2/ebs.tf
@@ -5,6 +5,7 @@ resource "aws_ebs_volume" "this" {
   availability_zone = var.ebs.az != null ? var.ebs.az : var.availability_zone
   type              = var.ebs.type
   iops              = var.ebs.iops
+  throughput        = var.ebs.throughput
 
   tags = {
     Name = var.ebs.tagName != null ? var.ebs.tagName : "${var.name}-ebs${var.ebs.size}g"

--- a/aws/ec2/instance.tf
+++ b/aws/ec2/instance.tf
@@ -38,6 +38,7 @@ resource "aws_instance" "this" {
     volume_size = var.root_volume_size
     volume_type = var.root_volume_type
     iops        = var.iops
+    throughput  = var.throughput
   }
 
   lifecycle {

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -26,6 +26,7 @@ variable "ebs" {
     az          = optional(string)
     type        = optional(string)
     iops        = optional(string)
+    throughput  = optional(string)
     tagName     = optional(string)
   })
 
@@ -124,6 +125,11 @@ variable "root_volume_type" {
 }
 
 variable "iops" {
+  type    = number
+  default = null
+}
+
+variable "throughput" {
   type    = number
   default = null
 }


### PR DESCRIPTION
## Summary
- Adds an optional `throughput` variable (mirrors the existing `iops` variable) for the root volume, wired into `aws_instance.this.root_block_device`
- Adds an optional `throughput` field to the `ebs` object variable, wired into `aws_ebs_volume.this`
- Both default to `null` (no behavior change for existing consumers)

## Motivation
Needed to raise gp3 IOPS/throughput on the fxcubic MT5 servers (currently capped at the gp3 baseline of 3000 IOPS / 125 MB/s) without recreating volumes — `iops`/`throughput`/`size` are not `ForceNew` in the AWS provider, so this is an in-place `ModifyVolume` update, no data loss.

## Test plan
- [x] `terraform validate` passes against `examples/ebs` with the updated module
- [ ] Consume new tag from `fxcubic` and confirm `terraform plan` shows in-place update only (no destroy/recreate)